### PR TITLE
Don't rely on in-reconciler state to determine last-in-cluster.

### DIFF
--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -22,10 +22,10 @@ import (
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	operatorclient "knative.dev/operator/pkg/client/injection/client"
 	knativeEventinginformer "knative.dev/operator/pkg/client/injection/informers/operator/v1alpha1/knativeeventing"
 	knereconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing"
 	"knative.dev/operator/pkg/reconciler"
@@ -60,9 +60,9 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	c := &Reconciler{
-		kubeClientSet: kubeClient,
-		config:        config,
-		eventings:     sets.NewString(),
+		kubeClientSet:     kubeClient,
+		operatorClientSet: operatorclient.Get(ctx),
+		config:            config,
 	}
 	impl := knereconciler.NewImpl(ctx, c)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Trying to determine the last resource in the cluster via state kept in the reconciler is racy and error-prone. Ask the API instead.

Deployments should also be removed via the ownerRef. An explicit deletion shouldn't be necessary.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo @jcrossley3 @aliok 
