### PR TITLE
Move metrics reporting into its own event handler.

### DIFF
--- a/pkg/reconciler/knativeserving/common/stats_reporter.go
+++ b/pkg/reconciler/knativeserving/common/stats_reporter.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reconciler
+package common
 
 import (
 	"context"

--- a/pkg/reconciler/knativeserving/common/stats_reporter_test.go
+++ b/pkg/reconciler/knativeserving/common/stats_reporter_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reconciler
+package common
 
 import (
 	"testing"

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -37,7 +37,6 @@ import (
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	knsreconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeserving"
 	listers "knative.dev/operator/pkg/client/listers/operator/v1alpha1"
-	"knative.dev/operator/pkg/reconciler"
 	"knative.dev/operator/pkg/reconciler/common"
 	ksc "knative.dev/operator/pkg/reconciler/knativeserving/common"
 	"knative.dev/operator/version"
@@ -48,9 +47,6 @@ import (
 
 const (
 	oldFinalizerName = "delete-knative-serving-manifest"
-	creationChange   = "creation"
-	editChange       = "edit"
-	deletionChange   = "deletion"
 )
 
 var (
@@ -64,8 +60,6 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// knativeServingClientSet allows us to configure Serving objects
 	knativeServingClientSet clientset.Interface
-	// statsReporter reports reconciler's metrics.
-	statsReporter reconciler.StatsReporter
 
 	// Listers index properties about resources
 	knativeServingLister listers.KnativeServingLister
@@ -119,22 +113,6 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, original *servingv1alpha
 	if err != nil {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
-	}
-
-	// Keep track of the number and generation of KnativeServings in the cluster.
-	newGen := original.Generation
-	if oldGen, ok := r.servings[key]; ok {
-		if newGen > oldGen {
-			r.statsReporter.ReportKnativeservingChange(key, editChange)
-		} else if newGen < oldGen {
-			return fmt.Errorf("reconciling obsolete generation of KnativeServing %s: newGen = %d and oldGen = %d", key, newGen, oldGen)
-		}
-	} else {
-		// No metrics are emitted when newGen > 1: the first reconciling of
-		// a new operator on an existing KnativeServing resource.
-		if newGen == 1 {
-			r.statsReporter.ReportKnativeservingChange(key, creationChange)
-		}
 	}
 	r.servings[key] = original.Generation
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This breaks the "state keeping" of the KnativeServing reconciler out of the reconciler and pushes it into a stateless event-handler format. Also moves the stats reporter code into a KnativeServing specific package.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @aliok @houshengbo 
