### PR TITLE
Remove unnecessary KnativeServing code and finishing touches.

### DIFF
--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -55,8 +55,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		injection.GetConfig(ctx),
 		mf.UseLogger(zapr.NewLogger(logger.Desugar()).WithName("manifestival")))
 	if err != nil {
-		logger.Error(err, "Error creating the Manifest for knative-eventing")
-		os.Exit(1)
+		logger.Fatalw("Error creating the Manifest for knative-eventing", zap.Error(err))
 	}
 
 	c := &Reconciler{

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -56,7 +56,8 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// kubeClientSet allows us to talk to the k8s for operator APIs
 	operatorClientSet clientset.Interface
-	config            mf.Manifest
+	// config is the manifest of KnativeEventing
+	config mf.Manifest
 	// Platform-specific behavior to affect the transform
 	platform common.Platforms
 }

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -69,8 +69,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		injection.GetConfig(ctx),
 		mf.UseLogger(zapr.NewLogger(logger.Desugar()).WithName("manifestival")))
 	if err != nil {
-		logger.Error(err, "Error creating the Manifest for knative-serving")
-		os.Exit(1)
+		logger.Fatalw("Error creating the Manifest for knative-serving", zap.Error(err))
 	}
 
 	c := &Reconciler{

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -57,7 +57,7 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// operatorClientSet allows us to configure operator objects
 	operatorClientSet clientset.Interface
-
+	// config is the manifest of KnativeServing
 	config mf.Manifest
 	// Platform-specific behavior to affect the transform
 	platform common.Platforms


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

As the title stays. All the status update code in KnativeServing is redundant because it uses genreconciler which does all that out of the box.

Also a few last finishing touches.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo 
