### PR TITLE
Densen up unit test definitions.

### DIFF
--- a/pkg/reconciler/knativeserving/common/certs_test.go
+++ b/pkg/reconciler/knativeserving/common/certs_test.go
@@ -21,70 +21,12 @@ import (
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	util "knative.dev/operator/pkg/reconciler/common/testing"
 )
 
 var log = zap.NewNop().Sugar()
-
-type customCertsTest struct {
-	name         string
-	input        servingv1alpha1.CustomCerts
-	expectError  bool
-	expectSource *v1.VolumeSource
-}
-
-var customCertsTests = []customCertsTest{
-	{
-		name: "FromSecret",
-		input: servingv1alpha1.CustomCerts{
-			Type: "Secret",
-			Name: "my-secret",
-		},
-		expectError: false,
-		expectSource: &v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName: "my-secret",
-			},
-		},
-	},
-	{
-		name: "FromConfigMap",
-		input: servingv1alpha1.CustomCerts{
-			Type: "ConfigMap",
-			Name: "my-map",
-		},
-		expectError: false,
-		expectSource: &v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: v1.LocalObjectReference{
-					Name: "my-map",
-				},
-			},
-		},
-	},
-	{
-		name:        "NoCerts",
-		input:       servingv1alpha1.CustomCerts{},
-		expectError: false,
-	},
-	{
-		name: "InvalidType",
-		input: servingv1alpha1.CustomCerts{
-			Type: "invalid",
-		},
-		expectError: true,
-	},
-	{
-		name: "MissingName",
-		input: servingv1alpha1.CustomCerts{
-			Type: "Secret",
-		},
-		expectError: true,
-	},
-}
 
 func TestOnlyTransformCustomCertsForController(t *testing.T) {
 	before := util.MakeDeployment("not-controller", v1.PodSpec{
@@ -111,51 +53,93 @@ func TestOnlyTransformCustomCertsForController(t *testing.T) {
 }
 
 func TestCustomCertsTransform(t *testing.T) {
-	for _, tt := range customCertsTests {
-		t.Run(tt.name, func(t *testing.T) {
-			runCustomCertsTransformTest(t, &tt)
-		})
-	}
-}
-
-func runCustomCertsTransformTest(t *testing.T, tt *customCertsTest) {
-	unstructured := util.MakeUnstructured(t, util.MakeDeployment("controller", v1.PodSpec{
-		Containers: []v1.Container{{
-			Name: "controller",
-		}},
-	}))
-	instance := &servingv1alpha1.KnativeServing{
-		Spec: servingv1alpha1.KnativeServingSpec{
-			ControllerCustomCerts: tt.input,
+	tests := []struct {
+		name         string
+		input        servingv1alpha1.CustomCerts
+		expectError  bool
+		expectSource *v1.VolumeSource
+	}{{
+		name: "FromSecret",
+		input: servingv1alpha1.CustomCerts{
+			Type: "Secret",
+			Name: "my-secret",
 		},
-	}
-	customCertsTransform := CustomCertsTransform(instance, log)
-	err := customCertsTransform(&unstructured)
-	if tt.expectError && err == nil {
-		t.Fatal("Transformer should've returned an error and did not")
-	}
-	validateCustomCertsTransform(t, tt, &unstructured)
-}
+		expectError: false,
+		expectSource: &v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: "my-secret",
+			},
+		},
+	}, {
+		name: "FromConfigMap",
+		input: servingv1alpha1.CustomCerts{
+			Type: "ConfigMap",
+			Name: "my-map",
+		},
+		expectError: false,
+		expectSource: &v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "my-map",
+				},
+			},
+		},
+	}, {
+		name:        "NoCerts",
+		input:       servingv1alpha1.CustomCerts{},
+		expectError: false,
+	}, {
+		name: "InvalidType",
+		input: servingv1alpha1.CustomCerts{
+			Type: "invalid",
+		},
+		expectError: true,
+	}, {
+		name: "MissingName",
+		input: servingv1alpha1.CustomCerts{
+			Type: "Secret",
+		},
+		expectError: true,
+	}}
 
-func validateCustomCertsTransform(t *testing.T, tt *customCertsTest, u *unstructured.Unstructured) {
-	deployment := &appsv1.Deployment{}
-	err := scheme.Scheme.Convert(u, deployment, nil)
-	util.AssertEqual(t, err, nil)
-	spec := deployment.Spec.Template.Spec
-	if tt.expectSource != nil {
-		util.AssertEqual(t, spec.Volumes[0].Name, customCertsNamePrefix+tt.input.Name)
-		util.AssertDeepEqual(t, &spec.Volumes[0].VolumeSource, tt.expectSource)
-		util.AssertDeepEqual(t, spec.Containers[0].Env[0], v1.EnvVar{
-			Name:  customCertsEnvName,
-			Value: customCertsMountPath,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unstructured := util.MakeUnstructured(t, util.MakeDeployment("controller", v1.PodSpec{
+				Containers: []v1.Container{{
+					Name: "controller",
+				}},
+			}))
+			instance := &servingv1alpha1.KnativeServing{
+				Spec: servingv1alpha1.KnativeServingSpec{
+					ControllerCustomCerts: tt.input,
+				},
+			}
+			customCertsTransform := CustomCertsTransform(instance, log)
+			err := customCertsTransform(&unstructured)
+			if tt.expectError && err == nil {
+				t.Fatal("Transformer should've returned an error and did not")
+			}
+
+			deployment := &appsv1.Deployment{}
+			err = scheme.Scheme.Convert(&unstructured, deployment, nil)
+			util.AssertEqual(t, err, nil)
+			spec := deployment.Spec.Template.Spec
+			if tt.expectSource != nil {
+				util.AssertEqual(t, spec.Volumes[0].Name, customCertsNamePrefix+tt.input.Name)
+				util.AssertDeepEqual(t, &spec.Volumes[0].VolumeSource, tt.expectSource)
+				util.AssertDeepEqual(t, spec.Containers[0].Env[0], v1.EnvVar{
+					Name:  customCertsEnvName,
+					Value: customCertsMountPath,
+				})
+				util.AssertDeepEqual(t, spec.Containers[0].VolumeMounts[0], v1.VolumeMount{
+					Name:      customCertsNamePrefix + tt.input.Name,
+					MountPath: customCertsMountPath,
+				})
+			} else {
+				util.AssertEqual(t, len(spec.Volumes), 0)
+				util.AssertEqual(t, len(spec.Containers[0].Env), 0)
+				util.AssertEqual(t, len(spec.Containers[0].VolumeMounts), 0)
+			}
 		})
-		util.AssertDeepEqual(t, spec.Containers[0].VolumeMounts[0], v1.VolumeMount{
-			Name:      customCertsNamePrefix + tt.input.Name,
-			MountPath: customCertsMountPath,
-		})
-	} else {
-		util.AssertEqual(t, len(spec.Volumes), 0)
-		util.AssertEqual(t, len(spec.Containers[0].Env), 0)
-		util.AssertEqual(t, len(spec.Containers[0].VolumeMounts), 0)
 	}
 }

--- a/pkg/reconciler/knativeserving/common/ha_test.go
+++ b/pkg/reconciler/knativeserving/common/ha_test.go
@@ -37,70 +37,59 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in       *unstructured.Unstructured
 		expected *unstructured.Unstructured
 		err      error
-	}{
-		{
-			name:     "No HA; ConfigMap",
-			config:   nil,
-			in:       makeUnstructuredConfigMap(t, nil),
-			expected: makeUnstructuredConfigMap(t, nil),
-		},
-		{
-			name:   "HA; ConfigMap",
-			config: makeHa(2),
-			in:     makeUnstructuredConfigMap(t, nil),
-			expected: makeUnstructuredConfigMap(t, map[string]string{
-				enabledComponentsKey: componentsValue,
-			}),
-		},
-		{
-			name:     "HA; controller",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "controller"),
-			expected: makeUnstructuredDeploymentReplicas(t, "controller", 2),
-		},
-		{
-			name:     "HA; autoscaler-hpa",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "autoscaler-hpa"),
-			expected: makeUnstructuredDeploymentReplicas(t, "autoscaler-hpa", 2),
-		},
-		{
-			name:     "HA; networking-certmanager",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "networking-certmanager"),
-			expected: makeUnstructuredDeploymentReplicas(t, "networking-certmanager", 2),
-		},
-		{
-			name:     "HA; networking-ns-cert",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "networking-ns-cert"),
-			expected: makeUnstructuredDeploymentReplicas(t, "networking-ns-cert", 2),
-		},
-		{
-			name:     "HA; networking-istio",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "networking-istio"),
-			expected: makeUnstructuredDeploymentReplicas(t, "networking-istio", 2),
-		},
-		{
-			name:     "HA; some-unsupported-controller",
-			config:   makeHa(2),
-			in:       makeUnstructuredDeployment(t, "some-unsupported-controller"),
-			expected: makeUnstructuredDeployment(t, "some-unsupported-controller"),
-		},
-		{
-			name:     "HA; adjust hpa",
-			config:   makeHa(2),
-			in:       makeUnstructuredHPA(t, "activator", 1),
-			expected: makeUnstructuredHPA(t, "activator", 2),
-		},
-		{
-			name:     "HA; keep higher hpa value",
-			config:   makeHa(2),
-			in:       makeUnstructuredHPA(t, "activator", 3),
-			expected: makeUnstructuredHPA(t, "activator", 3),
-		},
-	}
+	}{{
+		name:     "No HA; ConfigMap",
+		config:   nil,
+		in:       makeUnstructuredConfigMap(t, nil),
+		expected: makeUnstructuredConfigMap(t, nil),
+	}, {
+		name:   "HA; ConfigMap",
+		config: makeHa(2),
+		in:     makeUnstructuredConfigMap(t, nil),
+		expected: makeUnstructuredConfigMap(t, map[string]string{
+			enabledComponentsKey: componentsValue,
+		}),
+	}, {
+		name:     "HA; controller",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "controller"),
+		expected: makeUnstructuredDeploymentReplicas(t, "controller", 2),
+	}, {
+		name:     "HA; autoscaler-hpa",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "autoscaler-hpa"),
+		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler-hpa", 2),
+	}, {
+		name:     "HA; networking-certmanager",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "networking-certmanager"),
+		expected: makeUnstructuredDeploymentReplicas(t, "networking-certmanager", 2),
+	}, {
+		name:     "HA; networking-ns-cert",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "networking-ns-cert"),
+		expected: makeUnstructuredDeploymentReplicas(t, "networking-ns-cert", 2),
+	}, {
+		name:     "HA; networking-istio",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "networking-istio"),
+		expected: makeUnstructuredDeploymentReplicas(t, "networking-istio", 2),
+	}, {
+		name:     "HA; some-unsupported-controller",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "some-unsupported-controller"),
+		expected: makeUnstructuredDeployment(t, "some-unsupported-controller"),
+	}, {
+		name:     "HA; adjust hpa",
+		config:   makeHa(2),
+		in:       makeUnstructuredHPA(t, "activator", 1),
+		expected: makeUnstructuredHPA(t, "activator", 2),
+	}, {
+		name:     "HA; keep higher hpa value",
+		config:   makeHa(2),
+		in:       makeUnstructuredHPA(t, "activator", 3),
+		expected: makeUnstructuredHPA(t, "activator", 3),
+	}}
 
 	for i := range cases {
 		tc := cases[i]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This packs the unit tests more closely with their "type" for table tests to involve less function call hopping in the tests themselves.

This might be controversial and only reflects my opinion on what is easier to grasp from a test. Please feel free to bin this if that doesn't align with the wider opinion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo @jcrossley3 @aliok 