### PR TITLE
Eliminate the wasteful updates due to the aggregated rules

### DIFF
--- a/pkg/reconciler/knativeserving/common/aggregated_rules.go
+++ b/pkg/reconciler/knativeserving/common/aggregated_rules.go
@@ -39,7 +39,13 @@ func AggregationRuleTransform(client unstructuredGetter) mf.Transformer {
 			if err != nil {
 				return err
 			}
-			*u = *current
+			rules, found, err := unstructured.NestedSlice(current.Object, "rules")
+			if err != nil {
+				return err
+			}
+			if found {
+				return unstructured.SetNestedSlice(u.Object, rules, "rules")
+			}
 		}
 		return nil
 	}

--- a/pkg/reconciler/knativeserving/common/aggregated_rules.go
+++ b/pkg/reconciler/knativeserving/common/aggregated_rules.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type unstructuredGetter interface {
+	Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+}
+
+// AggregationRuleTransform
+func AggregationRuleTransform(client unstructuredGetter) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "ClusterRole" && u.Object["aggregationRule"] != nil {
+			// we rely on the controller manager to fill in rules so
+			// ours will always trigger an unnecessary update
+			current, err := client.Get(u)
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			*u = *current
+		}
+		return nil
+	}
+}

--- a/pkg/reconciler/knativeserving/common/aggregated_rules_test.go
+++ b/pkg/reconciler/knativeserving/common/aggregated_rules_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+	"sigs.k8s.io/yaml"
+)
+
+type ruleAggregationFixture struct {
+	Name              string
+	Input             *unstructured.Unstructured
+	Database          *unstructured.Unstructured
+	OverwriteExpected bool
+}
+
+var ruleAggregationData = []byte(`
+- name: "existing role has rules"
+  input:
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-admin
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          serving.knative.dev/controller: "true"
+    rules: []
+  database:
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-admin
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          serving.knative.dev/controller: "true"
+    rules:
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - services
+      verbs:
+      - watch
+  overwriteExpected: true
+- name: "no existing role"
+  input:
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: knative-serving-admin
+    aggregationRule:
+      clusterRoleSelectors:
+      - matchLabels:
+          serving.knative.dev/controller: "true"
+    rules: []
+  overwriteExpected: false
+`)
+
+func TestAggregationRuleTransform(t *testing.T) {
+	tests := []ruleAggregationFixture{}
+	err := yaml.Unmarshal(ruleAggregationData, &tests)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			runRuleAggregationTest(t, &test)
+		})
+	}
+}
+
+func runRuleAggregationTest(t *testing.T, test *ruleAggregationFixture) {
+	mock := mockGetter{test.Database}
+	original := test.Input.DeepCopy()
+	transformer := AggregationRuleTransform(&mock)
+	transformer(test.Input)
+	if test.OverwriteExpected {
+		util.AssertDeepEqual(t, test.Input, test.Database)
+	} else {
+		util.AssertDeepEqual(t, test.Input, original)
+	}
+}
+
+type mockGetter struct {
+	u *unstructured.Unstructured
+}
+
+func (m *mockGetter) Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if m.u == nil {
+		return nil, errors.NewNotFound(schema.GroupResource{}, "")
+	}
+	return m.u, nil
+}

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -155,6 +155,7 @@ func (r *Reconciler) transform(ctx context.Context, instance *servingv1alpha1.Kn
 		ksc.GatewayTransform(instance, logger),
 		ksc.CustomCertsTransform(instance, logger),
 		ksc.HighAvailabilityTransform(instance, logger),
+		ksc.AggregationRuleTransform(r.config.Client),
 	}
 	transforms := append(standard, platform...)
 	return r.config.Transform(transforms...)


### PR DESCRIPTION
For any `ClusterRole` with an `aggregationRule`, we read its rules from the database in the transformer, since the manifest will never contain the correct rules.
