### PR TITLE
Simplify deleteObsoleteResources using common helpers.

### DIFF
--- a/pkg/reconciler/common/unstructured.go
+++ b/pkg/reconciler/common/unstructured.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// NamespacedResource is an unstructured resource with the given apiVersion, kind, ns and name.
+func NamespacedResource(apiVersion, kind, ns, name string) *unstructured.Unstructured {
+	resource := &unstructured.Unstructured{}
+	resource.SetAPIVersion(apiVersion)
+	resource.SetKind(kind)
+	resource.SetNamespace(ns)
+	resource.SetName(name)
+	return resource
+}
+
+// ClusterScopedResource is an unstructured resource with the given apiVersion, kind and name.
+func ClusterScopedResource(apiVersion, kind, name string) *unstructured.Unstructured {
+	return NamespacedResource(apiVersion, kind, "", name)
+}

--- a/pkg/reconciler/common/unstructured_test.go
+++ b/pkg/reconciler/common/unstructured_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNamespacedResource(t *testing.T) {
+	got := NamespacedResource("v1", "ConfigMap", "testns", "testname")
+	want := &unstructured.Unstructured{}
+	want.SetAPIVersion("v1")
+	want.SetKind("ConfigMap")
+	want.SetNamespace("testns")
+	want.SetName("testname")
+
+	if !equality.Semantic.DeepEqual(got, want) {
+		t.Errorf("Got = %v, want %v", got, want)
+	}
+}
+
+func TestClusterScopedResource(t *testing.T) {
+	got := ClusterScopedResource("v1", "ConfigMap", "testname")
+	want := &unstructured.Unstructured{}
+	want.SetAPIVersion("v1")
+	want.SetKind("ConfigMap")
+	want.SetName("testname")
+
+	if !equality.Semantic.DeepEqual(got, want) {
+		t.Errorf("Got = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The `deleteObsoleteResources` functions have become very long behemoths, so this uses a few helpers and a loop to densen these pieces up significantly.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 @houshengbo 
