### PR TITLE
Bump ObservedGeneration at the beginning of reconcilation.

### DIFF
--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -112,6 +112,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha
 func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	ke.Status.InitializeConditions()
+	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
 	stages := []func(context.Context, *mf.Manifest, *eventingv1alpha1.KnativeEventing) error{

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -112,6 +112,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *servingv1alpha1
 func (r *Reconciler) ReconcileKind(ctx context.Context, ks *servingv1alpha1.KnativeServing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	ks.Status.InitializeConditions()
+	ks.Status.ObservedGeneration = ks.Generation
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
 	stages := []func(context.Context, *mf.Manifest, *servingv1alpha1.KnativeServing) error{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

`ObservedGeneration` informs the consumer that a reconciler has looked at a rolled out change to `Generation`. This is very useful to determine if a state has already been reconciled by only looking at the respective resource.

For example: If I roll out a change to the spec, initially my status will be "Ready", but Generation will be 2, ObservedGeneration will be 1. I now know that I cannot rely on that Ready state, because my last updated hasn't even been reconciled. I can only rely on it if Generation == ObservedGeneration which is a general pattern.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 @houshengbo 
