### PR TITLE
WIP: Add a global predicate to the manifest

### DIFF
--- a/pkg/reconciler/common/manifestWithPolicy.go
+++ b/pkg/reconciler/common/manifestWithPolicy.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+)
+
+// ManifestWithPolicy contains a global predicate for the manifest to be applied
+type ManifestWithPolicy struct {
+	// globalPredicate is the global policy used to install and uninstall manifest
+	GlobalPredicate mf.Predicate
+}

--- a/pkg/reconciler/knativeserving/common/gateway.go
+++ b/pkg/reconciler/knativeserving/common/gateway.go
@@ -21,25 +21,31 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/operator/pkg/reconciler/common"
 )
 
-func GatewayTransform(instance *servingv1alpha1.KnativeServing, log *zap.SugaredLogger) mf.Transformer {
+// GatewayTransform is the function that transforms the ingress gateways based on the CR configurations for
+// knative-ingress-gateway and cluster-local-gateway
+func GatewayTransform(instance *servingv1alpha1.KnativeServing, log *zap.SugaredLogger, manifestPolicy *common.ManifestWithPolicy) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		// Update the deployment with the new registry and tag
 		if u.GetAPIVersion() == "networking.istio.io/v1alpha3" && u.GetKind() == "Gateway" {
 			if u.GetName() == "knative-ingress-gateway" {
-				return updateKnativeIngressGateway(instance.Spec.KnativeIngressGateway, u, log)
+				return updateKnativeIngressGateway(instance.Spec.KnativeIngressGateway, u, log, manifestPolicy)
 			}
 			if u.GetName() == "cluster-local-gateway" {
-				return updateKnativeIngressGateway(instance.Spec.ClusterLocalGateway, u, log)
+				return updateKnativeIngressGateway(instance.Spec.ClusterLocalGateway, u, log, manifestPolicy)
 			}
 		}
 		return nil
 	}
 }
 
-func updateKnativeIngressGateway(gatewayOverrides servingv1alpha1.IstioGatewayOverride, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
+func updateKnativeIngressGateway(gatewayOverrides servingv1alpha1.IstioGatewayOverride, u *unstructured.Unstructured, log *zap.SugaredLogger,
+	manifestPolicy *common.ManifestWithPolicy) (error) {
 	if len(gatewayOverrides.Selector) > 0 {
+		// User will replace the default gateway with custom gateway, so there is no need to install the default gateway.
+		manifestPolicy.GlobalPredicate = mf.All(manifestPolicy.GlobalPredicate, mf.ByName(u.GetName()))
 		log.Debugw("Updating Gateway", "name", u.GetName(), "gatewayOverrides", gatewayOverrides)
 		unstructured.SetNestedStringMap(u.Object, gatewayOverrides.Selector, "spec", "selector")
 		log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)

--- a/pkg/reconciler/knativeserving/common/gateway_test.go
+++ b/pkg/reconciler/knativeserving/common/gateway_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package common
 
 import (
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/reconciler/common"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,6 +41,7 @@ func TestGatewayTransform(t *testing.T) {
 		knativeIngressGateway servingv1alpha1.IstioGatewayOverride
 		clusterLocalGateway   servingv1alpha1.IstioGatewayOverride
 		expected              map[string]string
+		expectedPolicy        mf.Predicate
 	}{{
 		name:        "UpdatesKnativeIngressGateway",
 		gatewayName: "knative-ingress-gateway",
@@ -107,7 +110,10 @@ func TestGatewayTransform(t *testing.T) {
 					ClusterLocalGateway:   tt.clusterLocalGateway,
 				},
 			}
-			gatewayTransform := GatewayTransform(instance, log)
+			manifestWithPolicy := &common.ManifestWithPolicy {
+				GlobalPredicate: mf.All(),
+			}
+			gatewayTransform := GatewayTransform(instance, log, manifestWithPolicy)
 			gatewayTransform(&unstructedGateway)
 
 			var gateway = &v1alpha3.Gateway{}

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -72,11 +72,16 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		logger.Fatalw("Error creating the Manifest for knative-serving", zap.Error(err))
 	}
 
+	manifestWithPolicy := &common.ManifestWithPolicy {
+		GlobalPredicate: mf.All(),
+	}
+
 	c := &Reconciler{
-		kubeClientSet:     kubeClient,
-		operatorClientSet: operatorclient.Get(ctx),
-		platform:          common.GetPlatforms(ctx),
-		config:            config,
+		kubeClientSet:      kubeClient,
+		operatorClientSet:  operatorclient.Get(ctx),
+		platform:           common.GetPlatforms(ctx),
+		config:             config,
+		manifestWithPolicy: manifestWithPolicy,
 	}
 	impl := knsreconciler.NewImpl(ctx, c)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* This PR added a global predicate effective on a reconciler scope. Each time manifest is applied, this predicate is used as filter.
* One use case this PR resolves is that when users specify the custom knative ingress and local gateways, we do not need to install the default gateways.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
