### PR TITLE
Fix the Kind in the GVK returned by KnativeEventing.

### DIFF
--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
@@ -28,7 +28,7 @@ var eventingCondSet = apis.NewLivingConditionSet(
 
 // GroupVersionKind returns SchemeGroupVersion of an KnativeEventing
 func (e *KnativeEventing) GroupVersionKind() schema.GroupVersionKind {
-	return SchemeGroupVersion.WithKind(Kind)
+	return SchemeGroupVersion.WithKind(KindKnativeEventing)
 }
 
 // GetCondition returns the current condition of a given condition type

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -37,7 +37,7 @@ func TestKnativeEventingGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
 		Group:   GroupName,
 		Version: SchemaVersion,
-		Kind:    Kind,
+		Kind:    KindKnativeEventing,
 	}
 	if got := r.GroupVersionKind(); got != want {
 		t.Errorf("got: %v, want: %v", got, want)

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
@@ -28,7 +28,7 @@ var conditions = apis.NewLivingConditionSet(
 
 // GroupVersionKind returns SchemeGroupVersion of a KnativeServing
 func (ks *KnativeServing) GroupVersionKind() schema.GroupVersionKind {
-	return SchemeGroupVersion.WithKind(Kind)
+	return SchemeGroupVersion.WithKind(KindKnativeServing)
 }
 
 // GetCondition returns the current condition of a given condition type

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
@@ -27,7 +27,7 @@ func TestKnativeServingGroupVersionKind(t *testing.T) {
 	want := schema.GroupVersionKind{
 		Group:   GroupName,
 		Version: SchemaVersion,
-		Kind:    Kind,
+		Kind:    KindKnativeServing,
 	}
 	if got := r.GroupVersionKind(); got != want {
 		t.Errorf("got: %v, want: %v", got, want)

--- a/pkg/apis/operator/v1alpha1/register.go
+++ b/pkg/apis/operator/v1alpha1/register.go
@@ -32,8 +32,10 @@ const (
 	// The Version of the schema. This is used for CRDs.
 	SchemaVersion = "v1alpha1"
 
-	// The Kind of the custom resource. This is used for CRDs.
-	Kind = "KnativeServing"
+	// KindKnativeEventing is the Kind of Knative Eventing in a GVK context.
+	KindKnativeEventing = "KnativeEventing"
+	// KindKnativeServing is the Kind of Knative Serving in a GVK context.
+	KindKnativeServing = "KnativeServing"
 )
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This surprised me. Apparently nothing uses the `GroupVersionKind` helper (yet). But this is just a bug, a KnativeEventing is not a KnativeServing!

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @aliok @houshengbo 
