### PR TITLE
Align Eventing conditions with Serving conditions.

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "knative.dev/pkg/apis"
+
+const (
+	// DependenciesInstalled is a Condition indicating that potential dependencies have
+	// been installed correctly.
+	DependenciesInstalled apis.ConditionType = "DependenciesInstalled"
+	// InstallSucceeded is a Condition indiciating that the installation of the component
+	// itself has been successful.
+	InstallSucceeded apis.ConditionType = "InstallSucceeded"
+	// DeploymentsAvailable is a Condition indicating whether or not the Deployments of
+	// the respective component have come up successfully.
+	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
+)

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -35,103 +35,103 @@ func TestKnativeEventingGroupVersionKind(t *testing.T) {
 }
 
 func TestKnativeEventingHappyPath(t *testing.T) {
-	ks := &KnativeEventingStatus{}
-	ks.InitializeConditions()
+	ke := &KnativeEventingStatus{}
+	ke.InitializeConditions()
 
-	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ke, InstallSucceeded, t)
 
 	// Install succeeds.
-	ks.MarkInstallSucceeded()
+	ke.MarkInstallSucceeded()
 	// Dependencies are assumed successful too.
-	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
 
 	// Deployments are not available at first.
-	ks.MarkDeploymentsNotReady()
-	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
-	apistest.CheckConditionFailed(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
-	if ready := ks.IsReady(); ready {
-		t.Errorf("ks.IsReady() = %v, want false", ready)
+	ke.MarkDeploymentsNotReady()
+	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
+	apistest.CheckConditionFailed(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
+	if ready := ke.IsReady(); ready {
+		t.Errorf("ke.IsReady() = %v, want false", ready)
 	}
 
 	// Deployments become ready and we're good.
-	ks.MarkDeploymentsAvailable()
-	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
-	if ready := ks.IsReady(); !ready {
-		t.Errorf("ks.IsReady() = %v, want true", ready)
+	ke.MarkDeploymentsAvailable()
+	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
+	if ready := ke.IsReady(); !ready {
+		t.Errorf("ke.IsReady() = %v, want true", ready)
 	}
 }
 
 func TestKnativeEventingErrorPath(t *testing.T) {
-	ks := &KnativeEventingStatus{}
-	ks.InitializeConditions()
+	ke := &KnativeEventingStatus{}
+	ke.InitializeConditions()
 
-	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
+	apistest.CheckConditionOngoing(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ke, InstallSucceeded, t)
 
 	// Install fails.
-	ks.MarkInstallFailed("test")
-	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionFailed(ks, InstallSucceeded, t)
+	ke.MarkInstallFailed("test")
+	apistest.CheckConditionOngoing(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionFailed(ke, InstallSucceeded, t)
 
 	// Dependencies are installing.
-	ks.MarkDependencyInstalling("testing")
-	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionFailed(ks, InstallSucceeded, t)
+	ke.MarkDependencyInstalling("testing")
+	apistest.CheckConditionFailed(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionFailed(ke, InstallSucceeded, t)
 
 	// Install now succeeds.
-	ks.MarkInstallSucceeded()
-	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
-	if ready := ks.IsReady(); ready {
-		t.Errorf("ks.IsReady() = %v, want false", ready)
+	ke.MarkInstallSucceeded()
+	apistest.CheckConditionFailed(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
+	if ready := ke.IsReady(); ready {
+		t.Errorf("ke.IsReady() = %v, want false", ready)
 	}
 
 	// Deployments become ready
-	ks.MarkDeploymentsAvailable()
-	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
-	if ready := ks.IsReady(); ready {
-		t.Errorf("ks.IsReady() = %v, want false", ready)
+	ke.MarkDeploymentsAvailable()
+	apistest.CheckConditionFailed(ke, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
+	if ready := ke.IsReady(); ready {
+		t.Errorf("ke.IsReady() = %v, want false", ready)
 	}
 
 	// Finally, dependencies become available.
-	ks.MarkDependenciesInstalled()
-	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
-	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
-	if ready := ks.IsReady(); !ready {
-		t.Errorf("ks.IsReady() = %v, want true", ready)
+	ke.MarkDependenciesInstalled()
+	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
+	if ready := ke.IsReady(); !ready {
+		t.Errorf("ke.IsReady() = %v, want true", ready)
 	}
 }
 
 func TestKnativeEventingExternalDependency(t *testing.T) {
-	ks := &KnativeEventingStatus{}
-	ks.InitializeConditions()
+	ke := &KnativeEventingStatus{}
+	ke.InitializeConditions()
 
 	// External marks dependency as failed.
-	ks.MarkDependencyMissing("test")
+	ke.MarkDependencyMissing("test")
 
 	// Install succeeds.
-	ks.MarkInstallSucceeded()
-	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	ke.MarkInstallSucceeded()
+	apistest.CheckConditionFailed(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
 
 	// Dependencies are now ready.
-	ks.MarkDependenciesInstalled()
-	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
-	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
-	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	ke.MarkDependenciesInstalled()
+	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
 }

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -18,19 +18,9 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	apistest "knative.dev/pkg/apis/testing"
 )
-
-var ignoreAllButTypeAndStatus = cmpopts.IgnoreFields(
-	apis.Condition{},
-	"LastTransitionTime", "Message", "Reason", "Severity")
 
 func TestKnativeEventingGroupVersionKind(t *testing.T) {
 	r := &KnativeEventing{}
@@ -44,226 +34,104 @@ func TestKnativeEventingGroupVersionKind(t *testing.T) {
 	}
 }
 
-func TestKnativeEventingStatusGetCondition(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	if a := ke.GetCondition(InstallSucceeded); a != nil {
-		t.Errorf("empty EventingStatus returned %v when expected nil", a)
-	}
-	mc := &apis.Condition{
-		Type:   InstallSucceeded,
-		Status: corev1.ConditionTrue,
-	}
-	ke.MarkInstallationReady()
-	if diff := cmp.Diff(mc, ke.GetCondition(InstallSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
-		t.Errorf("GetCondition refs diff (-want +got): %v", diff)
-	}
-}
+func TestKnativeEventingHappyPath(t *testing.T) {
+	ks := &KnativeEventingStatus{}
+	ks.InitializeConditions()
 
-func TestKnativeEventingStatusEventingInstalled(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	mc := &apis.Condition{
-		Type:   InstallSucceeded,
-		Status: corev1.ConditionTrue,
-	}
-	ke.MarkInstallationReady()
-	if diff := cmp.Diff(mc, ke.GetCondition(InstallSucceeded), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
-		t.Errorf("GetCondition refs diff (-want +got): %v", diff)
-	}
-}
+	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
 
-func TestKnativeEventingStatusEventingFailed(t *testing.T) {
-	reason := "NotReady"
-	message := "Waiting on deployments"
-	ke := &KnativeEventingStatus{}
-	mc := &apis.Condition{
-		Type:    EventingConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  reason,
-		Message: message,
+	// Install succeeds.
+	ks.MarkInstallSucceeded()
+	// Dependencies are assumed successful too.
+	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+
+	// Deployments are not available at first.
+	ks.MarkDeploymentsNotReady()
+	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
+	apistest.CheckConditionFailed(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	if ready := ks.IsReady(); ready {
+		t.Errorf("ks.IsReady() = %v, want false", ready)
 	}
-	ke.MarkEventingFailed(reason, message)
-	if diff := cmp.Diff(mc, ke.GetCondition(EventingConditionReady), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
-		t.Errorf("GetCondition refs diff (-want +got): %v", diff)
+
+	// Deployments become ready and we're good.
+	ks.MarkDeploymentsAvailable()
+	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	if ready := ks.IsReady(); !ready {
+		t.Errorf("ks.IsReady() = %v, want true", ready)
 	}
 }
 
-func TestKnativeEventingStatusNotReady(t *testing.T) {
-	reason := "NotReady"
-	message := "Waiting on deployments"
-	ke := &KnativeEventingStatus{}
-	mc := &apis.Condition{
-		Type:    EventingConditionReady,
-		Status:  corev1.ConditionUnknown,
-		Reason:  reason,
-		Message: message,
+func TestKnativeEventingErrorPath(t *testing.T) {
+	ks := &KnativeEventingStatus{}
+	ks.InitializeConditions()
+
+	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
+
+	// Install fails.
+	ks.MarkInstallFailed("test")
+	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionFailed(ks, InstallSucceeded, t)
+
+	// Dependencies are installing.
+	ks.MarkDependencyInstalling("testing")
+	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionFailed(ks, InstallSucceeded, t)
+
+	// Install now succeeds.
+	ks.MarkInstallSucceeded()
+	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	if ready := ks.IsReady(); ready {
+		t.Errorf("ks.IsReady() = %v, want false", ready)
 	}
-	ke.MarkEventingNotReady(reason, message)
-	if diff := cmp.Diff(mc, ke.GetCondition(EventingConditionReady), cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime")); diff != "" {
-		t.Errorf("GetCondition refs diff (-want +got): %v", diff)
+
+	// Deployments become ready
+	ks.MarkDeploymentsAvailable()
+	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	if ready := ks.IsReady(); ready {
+		t.Errorf("ks.IsReady() = %v, want false", ready)
+	}
+
+	// Finally, dependencies become available.
+	ks.MarkDependenciesInstalled()
+	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
+	apistest.CheckConditionSucceeded(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
+	if ready := ks.IsReady(); !ready {
+		t.Errorf("ks.IsReady() = %v, want true", ready)
 	}
 }
 
-func TestKnativeEventingStatusReady(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	ke.InitializeConditions()
-	apistest.CheckConditionOngoing(ke, EventingConditionReady, t)
+func TestKnativeEventingExternalDependency(t *testing.T) {
+	ks := &KnativeEventingStatus{}
+	ks.InitializeConditions()
 
-	ke.MarkInstallationReady()
-	ke.MarkEventingReady()
-	apistest.CheckConditionSucceeded(ke, EventingConditionReady, t)
-}
+	// External marks dependency as failed.
+	ks.MarkDependencyMissing("test")
 
-func TestKnativeEventingStatusIsReady(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	ke.MarkInstallationReady()
-	ke.MarkEventingReady()
-	if diff := cmp.Diff(true, ke.IsReady()); diff != "" {
-		t.Errorf("IsReady refs diff (-want +got): %v", diff)
-	}
-}
+	// Install succeeds.
+	ks.MarkInstallSucceeded()
+	apistest.CheckConditionFailed(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
 
-func TestKnativeEventingSuccesssFlow(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	ke.InitializeConditions()
-
-	apistest.CheckConditionOngoing(ke, EventingConditionReady, t)
-
-	// Installation succeeds
-	ke.MarkInstallationReady()
-	ke.MarkEventingReady()
-	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
-	apistest.CheckConditionSucceeded(ke, EventingConditionReady, t)
-}
-
-func TestKnativeEventingFailureFlow(t *testing.T) {
-	ke := &KnativeEventingStatus{}
-	ke.InitializeConditions()
-
-	apistest.CheckConditionOngoing(ke, EventingConditionReady, t)
-
-	// Installation not ready
-	ke.MarkInstallationNotReady("slow", "slow cpu.")
-	apistest.CheckConditionOngoing(ke, InstallSucceeded, t)
-	apistest.CheckConditionOngoing(ke, EventingConditionReady, t)
-
-	// Installation failed
-	ke.MarkInstallationFailed("failed", "no resources.")
-	ke.MarkEventingFailed("failed", "installation failed.")
-	apistest.CheckConditionFailed(ke, InstallSucceeded, t)
-	apistest.CheckConditionFailed(ke, EventingConditionReady, t)
-}
-
-func TestKnativeEventingInitializeConditions(t *testing.T) {
-	tests := []struct {
-		name string
-		ke   *KnativeEventingStatus
-		want *KnativeEventingStatus
-	}{{
-		name: "empty",
-		ke:   &KnativeEventingStatus{},
-		want: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		},
-	}, {
-		name: "eventingConditionNotReady",
-		ke: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionFalse,
-				}},
-			},
-		},
-		want: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionUnknown,
-				}, {
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionFalse,
-				}},
-			},
-		},
-	}, {
-		name: "eventingConditionReady",
-		ke: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionTrue,
-				}},
-			},
-		},
-		want: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionTrue,
-				}},
-			},
-		},
-	}, {
-		name: "installSucceeded",
-		ke: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionTrue,
-				}},
-			},
-		},
-		want: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionTrue,
-				}, {
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		},
-	}, {
-		name: "installNotSucceeded",
-		ke: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionFalse,
-				}},
-			},
-		},
-		want: &KnativeEventingStatus{
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   InstallSucceeded,
-					Status: corev1.ConditionFalse,
-				}, {
-					Type:   EventingConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.ke.InitializeConditions()
-			if diff := cmp.Diff(test.want, test.ke, ignoreAllButTypeAndStatus); diff != "" {
-				t.Errorf("unexpected conditions (-want, +got) = %v", diff)
-			}
-		})
-	}
+	// Dependencies are now ready.
+	ks.MarkDependenciesInstalled()
+	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
+	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
+	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
 }

--- a/pkg/apis/operator/v1alpha1/knativeeventing_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_types.go
@@ -17,7 +17,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -75,8 +74,3 @@ type KnativeEventingList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []KnativeEventing `json:"items"`
 }
-
-const (
-	// EventingConditionReady is set when the KnativeEventing Operator is installed, configured and ready.
-	EventingConditionReady = apis.ConditionReady
-)

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
@@ -20,7 +20,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var conditions = apis.NewLivingConditionSet(
+var servingCondSet = apis.NewLivingConditionSet(
 	DependenciesInstalled,
 	DeploymentsAvailable,
 	InstallSucceeded,
@@ -33,22 +33,22 @@ func (ks *KnativeServing) GroupVersionKind() schema.GroupVersionKind {
 
 // GetCondition returns the current condition of a given condition type
 func (is *KnativeServingStatus) GetCondition(t apis.ConditionType) *apis.Condition {
-	return conditions.Manage(is).GetCondition(t)
+	return servingCondSet.Manage(is).GetCondition(t)
 }
 
 // InitializeConditions initializes conditions of an KnativeServingStatus
 func (is *KnativeServingStatus) InitializeConditions() {
-	conditions.Manage(is).InitializeConditions()
+	servingCondSet.Manage(is).InitializeConditions()
 }
 
 // IsReady looks at the conditions returns true if they are all true.
 func (is *KnativeServingStatus) IsReady() bool {
-	return conditions.Manage(is).IsHappy()
+	return servingCondSet.Manage(is).IsHappy()
 }
 
 // MarkInstallSucceeded marks the InstallationSucceeded status as true.
 func (is *KnativeServingStatus) MarkInstallSucceeded() {
-	conditions.Manage(is).MarkTrue(InstallSucceeded)
+	servingCondSet.Manage(is).MarkTrue(InstallSucceeded)
 	if is.GetCondition(DependenciesInstalled).IsUnknown() {
 		// Assume deps are installed if we're not sure
 		is.MarkDependenciesInstalled()
@@ -58,7 +58,7 @@ func (is *KnativeServingStatus) MarkInstallSucceeded() {
 // MarkInstallFailed marks the InstallationSucceeded status as false with the given
 // message.
 func (is *KnativeServingStatus) MarkInstallFailed(msg string) {
-	conditions.Manage(is).MarkFalse(
+	servingCondSet.Manage(is).MarkFalse(
 		InstallSucceeded,
 		"Error",
 		"Install failed with message: %s", msg)
@@ -66,13 +66,13 @@ func (is *KnativeServingStatus) MarkInstallFailed(msg string) {
 
 // MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
 func (is *KnativeServingStatus) MarkDeploymentsAvailable() {
-	conditions.Manage(is).MarkTrue(DeploymentsAvailable)
+	servingCondSet.Manage(is).MarkTrue(DeploymentsAvailable)
 }
 
 // MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 // it's waiting for deployments.
 func (is *KnativeServingStatus) MarkDeploymentsNotReady() {
-	conditions.Manage(is).MarkFalse(
+	servingCondSet.Manage(is).MarkFalse(
 		DeploymentsAvailable,
 		"NotReady",
 		"Waiting on deployments")
@@ -80,13 +80,13 @@ func (is *KnativeServingStatus) MarkDeploymentsNotReady() {
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.
 func (is *KnativeServingStatus) MarkDependenciesInstalled() {
-	conditions.Manage(is).MarkTrue(DependenciesInstalled)
+	servingCondSet.Manage(is).MarkTrue(DependenciesInstalled)
 }
 
 // MarkDependencyInstalling marks the DependenciesInstalled status as false with the
 // given message.
 func (is *KnativeServingStatus) MarkDependencyInstalling(msg string) {
-	conditions.Manage(is).MarkFalse(
+	servingCondSet.Manage(is).MarkFalse(
 		DependenciesInstalled,
 		"Installing",
 		"Dependency installing: %s", msg)
@@ -95,7 +95,7 @@ func (is *KnativeServingStatus) MarkDependencyInstalling(msg string) {
 // MarkDependencyMissing marks the DependenciesInstalled status as false with the
 // given message.
 func (is *KnativeServingStatus) MarkDependencyMissing(msg string) {
-	conditions.Manage(is).MarkFalse(
+	servingCondSet.Manage(is).MarkFalse(
 		DependenciesInstalled,
 		"Error",
 		"Dependency missing: %s", msg)

--- a/pkg/apis/operator/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_types.go
@@ -18,14 +18,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
-)
-
-const (
-	DependenciesInstalled apis.ConditionType = "DependenciesInstalled"
-	InstallSucceeded      apis.ConditionType = "InstallSucceeded"
-	DeploymentsAvailable  apis.ConditionType = "DeploymentsAvailable"
 )
 
 // Registry defines image overrides of knative images.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

One more step towards reusable functions between Eventing and Serving: This aligns the conditions and helpers for setting those conditions between Eventing and Serving.

For now, the helper code is mostly a copy. Potential collapsing of the repetetiveness might come later. This is more about the calling site than it is about the definition site.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 @houshengbo 
