### PR TITLE
Collapse common spec fields into a CommonSpec.

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package v1alpha1
 
-import "knative.dev/pkg/apis"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
 
 const (
 	// DependenciesInstalled is a Condition indicating that potential dependencies have
@@ -29,3 +32,53 @@ const (
 	// the respective component have come up successfully.
 	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
 )
+
+// CommonSpec unifies common fields and functions on the Spec.
+type CommonSpec struct {
+	// A means to override the corresponding entries in the upstream configmaps
+	// +optional
+	Config map[string]map[string]string `json:"config,omitempty"`
+
+	// A means to override the corresponding deployment images in the upstream.
+	// If no registry is provided, the knative release images will be used.
+	// +optional
+	Registry Registry `json:"registry,omitempty"`
+
+	// Override containers' resource requirements
+	// +optional
+	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
+}
+
+// Config represents a map of upstream config map data.
+type Config map[string]map[string]string
+
+// Registry defines image overrides of knative images.
+// This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+// The default value is used as a default format to override for all knative deployments.
+// The override values are specific to each knative deployment.
+// +k8s:openapi-gen=true
+type Registry struct {
+	// The default image reference template to use for all knative images.
+	// It takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+	// ${NAME} will be replaced by the deployment container name, or caching.internal.knative.dev/v1alpha1/Image name.
+	// +optional
+	Default string `json:"default,omitempty"`
+
+	// A map of a container name or image name to the full image location of the individual knative image.
+	// +optional
+	Override map[string]string `json:"override,omitempty"`
+
+	// A list of secrets to be used when pulling the knative images. The secret must be created in the
+	// same namespace as the knative-serving deployments, and not the namespace of this resource.
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+}
+
+// ResourceRequirementsOverride enables the user to override any container's
+// resource requests/limits specified in the embedded manifest
+type ResourceRequirementsOverride struct {
+	// The container name
+	Container string `json:"container"`
+	// The desired ResourceRequirements
+	corev1.ResourceRequirements
+}

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -49,9 +49,6 @@ type CommonSpec struct {
 	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
 }
 
-// Config represents a map of upstream config map data.
-type Config map[string]map[string]string
-
 // Registry defines image overrides of knative images.
 // This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
 // The default value is used as a default format to override for all knative deployments.

--- a/pkg/apis/operator/v1alpha1/knativeeventing_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_types.go
@@ -37,18 +37,7 @@ type KnativeEventing struct {
 // KnativeEventingSpec defines the desired state of KnativeEventing
 // +k8s:openapi-gen=true
 type KnativeEventingSpec struct {
-	// A means to override the corresponding entries in the upstream configmaps
-	// +optional
-	Config map[string]map[string]string `json:"config,omitempty"`
-
-	// A means to override the corresponding deployment images in the upstream.
-	// If no registry is provided, the knative release images will be used.
-	// +optional
-	Registry Registry `json:"registry,omitempty"`
-
-	// Override containers' resource requirements
-	// +optional
-	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
+	CommonSpec `json:",inline"`
 
 	// The default broker type to use for the brokers Knative creates.
 	// If no value is provided, ChannelBasedBroker will be used.

--- a/pkg/apis/operator/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_types.go
@@ -16,32 +16,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
-
-// Registry defines image overrides of knative images.
-// This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-// The default value is used as a default format to override for all knative deployments.
-// The override values are specific to each knative deployment.
-// +k8s:openapi-gen=true
-type Registry struct {
-	// The default image reference template to use for all knative images.
-	// It takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-	// ${NAME} will be replaced by the deployment container name, or caching.internal.knative.dev/v1alpha1/Image name.
-	// +optional
-	Default string `json:"default,omitempty"`
-
-	// A map of a container name or image name to the full image location of the individual knative image.
-	// +optional
-	Override map[string]string `json:"override,omitempty"`
-
-	// A list of secrets to be used when pulling the knative images. The secret must be created in the
-	// same namespace as the knative-serving deployments, and not the namespace of this resource.
-	// +optional
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-}
 
 // IstioGatewayOverride override the knative-ingress-gateway and cluster-local-gateway
 type IstioGatewayOverride struct {
@@ -68,26 +45,10 @@ type HighAvailability struct {
 	Replicas int32 `json:"replicas"`
 }
 
-// ResourceRequirementsOverride enables the user to override any container's
-// resource requests/limits specified in the embedded manifest
-type ResourceRequirementsOverride struct {
-	// The container name
-	Container string `json:"container"`
-	// The desired ResourceRequirements
-	corev1.ResourceRequirements
-}
-
 // KnativeServingSpec defines the desired state of KnativeServing
 // +k8s:openapi-gen=true
 type KnativeServingSpec struct {
-	// A means to override the corresponding entries in the upstream configmaps
-	// +optional
-	Config map[string]map[string]string `json:"config,omitempty"`
-
-	// A means to override the corresponding deployment images in the upstream.
-	// If no registry is provided, the knative release images will be used.
-	// +optional
-	Registry Registry `json:"registry,omitempty"`
+	CommonSpec `json:",inline"`
 
 	// A means to override the knative-ingress-gateway
 	KnativeIngressGateway IstioGatewayOverride `json:"knative-ingress-gateway,omitempty"`
@@ -101,10 +62,6 @@ type KnativeServingSpec struct {
 	// Allows specification of HA control plane
 	// +optional
 	HighAvailability *HighAvailability `json:"high-availability,omitempty"`
-
-	// Override containers' resource requirements
-	// +optional
-	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
 }
 
 // KnativeServingStatus defines the observed state of KnativeServing

--- a/pkg/reconciler/common/images_test.go
+++ b/pkg/reconciler/common/images_test.go
@@ -366,7 +366,9 @@ func runImageTransformTest(t *testing.T, tt *updateImageSpecTest) {
 	unstructuredImage := util.MakeUnstructured(t, makeImage(t, tt))
 	instance := &v1alpha1.KnativeServing{
 		Spec: v1alpha1.KnativeServingSpec{
-			Registry: tt.registry,
+			CommonSpec: v1alpha1.CommonSpec{
+				Registry: tt.registry,
+			},
 		},
 	}
 	imageTransform := ImageTransform(&instance.Spec.Registry, log)

--- a/test/resources/knativeserving.go
+++ b/test/resources/knativeserving.go
@@ -118,13 +118,15 @@ func getDeploymentStatus(d *v1.Deployment) corev1.ConditionStatus {
 
 func getTestKSOperatorCRSpec() v1alpha1.KnativeServingSpec {
 	return v1alpha1.KnativeServingSpec{
-		Config: map[string]map[string]string{
-			DefaultsConfigKey: {
-				"revision-timeout-seconds": "200",
-			},
-			LoggingConfigKey: {
-				"loglevel.controller": "debug",
-				"loglevel.autoscaler": "debug",
+		CommonSpec: v1alpha1.CommonSpec{
+			Config: map[string]map[string]string{
+				DefaultsConfigKey: {
+					"revision-timeout-seconds": "200",
+				},
+				LoggingConfigKey: {
+					"loglevel.controller": "debug",
+					"loglevel.autoscaler": "debug",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This forms part of the basis to reduce repetition once we're moving forward with the interfaces proposed in #54.

I wanted to put this one out for discussion early as this is a **breaking change** in the construction of KnativeServing/KnativeEventing resources (see the test changes below). Do we want to go that route? The tradeoff is accepting this change vs. repeating accessor functions for both Eventing and Serving.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @aliok @houshengbo @jcrossley3 
