### PR TITLE
Add an interface for common status mutations.

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -33,6 +33,35 @@ const (
 	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
 )
 
+// KComponentStatus is a common interface for status mutations of all known types.
+type KComponentStatus interface {
+	// MarkInstallSucceeded marks the InstallationSucceeded status as true.
+	MarkInstallSucceeded()
+	// MarkInstallFailed marks the InstallationSucceeded status as false with the given
+	// message.
+	MarkInstallFailed(msg string)
+
+	// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
+	MarkDeploymentsAvailable()
+	// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
+	// it's waiting for deployments.
+	MarkDeploymentsNotReady()
+
+	// MarkDependenciesInstalled marks the DependenciesInstalled status as true.
+	MarkDependenciesInstalled()
+	// MarkDependencyInstalling marks the DependenciesInstalled status as false with the
+	// given message.
+	MarkDependencyInstalling(msg string)
+	// MarkDependencyMissing marks the DependenciesInstalled status as false with the
+	// given message.
+	MarkDependencyMissing(msg string)
+
+	// GetVersion gets the currently installed version of the component.
+	GetVersion() string
+	// SetVersion sets the currently installed version of the component.
+	SetVersion(version string)
+}
+
 // CommonSpec unifies common fields and functions on the Spec.
 type CommonSpec struct {
 	// A means to override the corresponding entries in the upstream configmaps

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
@@ -21,10 +21,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var eventingCondSet = apis.NewLivingConditionSet(
-	DependenciesInstalled,
-	DeploymentsAvailable,
-	InstallSucceeded,
+var (
+	_ KComponentStatus = (*KnativeEventingStatus)(nil)
+
+	eventingCondSet = apis.NewLivingConditionSet(
+		DependenciesInstalled,
+		DeploymentsAvailable,
+		InstallSucceeded,
+	)
 )
 
 // GroupVersionKind returns SchemeGroupVersion of an KnativeEventing
@@ -101,4 +105,14 @@ func (es *KnativeEventingStatus) MarkDependencyMissing(msg string) {
 		DependenciesInstalled,
 		"Error",
 		"Dependency missing: %s", msg)
+}
+
+// GetVersion gets the currently installed version of the component.
+func (es *KnativeEventingStatus) GetVersion() string {
+	return es.Version
+}
+
+// SetVersion sets the currently installed version of the component.
+func (es *KnativeEventingStatus) SetVersion(version string) {
+	es.Version = version
 }

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
@@ -20,10 +20,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var servingCondSet = apis.NewLivingConditionSet(
-	DependenciesInstalled,
-	DeploymentsAvailable,
-	InstallSucceeded,
+var (
+	_ KComponentStatus = (*KnativeServingStatus)(nil)
+
+	servingCondSet = apis.NewLivingConditionSet(
+		DependenciesInstalled,
+		DeploymentsAvailable,
+		InstallSucceeded,
+	)
 )
 
 // GroupVersionKind returns SchemeGroupVersion of a KnativeServing
@@ -99,4 +103,14 @@ func (is *KnativeServingStatus) MarkDependencyMissing(msg string) {
 		DependenciesInstalled,
 		"Error",
 		"Dependency missing: %s", msg)
+}
+
+// GetVersion gets the currently installed version of the component.
+func (is *KnativeServingStatus) GetVersion() string {
+	return is.Version
+}
+
+// SetVersion sets the currently installed version of the component.
+func (is *KnativeServingStatus) SetVersion(version string) {
+	is.Version = version
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

A big stepping stone towards reusable business logic: Unify the status of KnativeServing and Eventing in an interface.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 @houshengbo 
