### PR TITLE
Add verify-codegen.sh to be run by presubmit.

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
+
+readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
+
+cleanup() {
+  rm -rf "${TMP_DIFFROOT}"
+}
+
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+# Save working tree state
+mkdir -p "${TMP_DIFFROOT}/pkg"
+cp -aR "${REPO_ROOT_DIR}/go.sum" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
+
+# TODO(mattmoor): We should be able to rm -rf pkg/client/ and vendor/
+
+"${REPO_ROOT_DIR}/hack/update-codegen.sh"
+echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
+ret=0
+diff -Nupr --no-dereference "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
+diff -Nupr --no-dereference "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+
+# Restore working tree state
+rm -fr "${TMP_DIFFROOT}/config"
+rm -fr "${REPO_ROOT_DIR}/go.sum" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor"
+cp -aR "${TMP_DIFFROOT}"/* "${REPO_ROOT_DIR}"
+
+if [[ $ret -eq 0 ]]
+then
+  echo "${REPO_ROOT_DIR} up to date."
+else
+  echo "ERROR: ${REPO_ROOT_DIR} is out of date. Please run ./hack/update-codegen.sh"
+  exit 1
+fi


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

I forgot to run codegen in my last PRs and nothing noticed that. This adds the `verify-codegen.sh` script from Serving (with slight tweaks). Presubmit automatically picks that up and checks the generated code is recent. That avoids these mistakes altogether.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @aliok @houshengbo @jcrossley3 
