### PR TITLE
Move the deployment check into common code and add tests.

### DIFF
--- a/pkg/reconciler/common/deployments.go
+++ b/pkg/reconciler/common/deployments.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+// CheckDeployments checks all deployments in the given manifest and updates the given
+// status with the status of the deployments.
+func CheckDeployments(kube kubernetes.Interface, manifest *mf.Manifest, status v1alpha1.KComponentStatus) error {
+	for _, u := range manifest.Filter(mf.ByKind("Deployment")).Resources() {
+		deployment, err := kube.AppsV1().Deployments(u.GetNamespace()).Get(u.GetName(), metav1.GetOptions{})
+		if err != nil {
+			status.MarkDeploymentsNotReady()
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if !isDeploymentAvailable(deployment) {
+			status.MarkDeploymentsNotReady()
+			return nil
+		}
+	}
+	status.MarkDeploymentsAvailable()
+	return nil
+}
+
+func isDeploymentAvailable(d *appsv1.Deployment) bool {
+	for _, c := range d.Status.Conditions {
+		if c.Type == appsv1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/common/deployments_test.go
+++ b/pkg/reconciler/common/deployments_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fake "k8s.io/client-go/kubernetes/fake"
+	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+func TestCheckDeployments(t *testing.T) {
+	readyDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "ready",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+
+	notReadyDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "notReady",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		inManifest []unstructured.Unstructured
+		inAPI      []runtime.Object
+		wantError  bool
+		wantStatus corev1.ConditionStatus
+	}{{
+		name: "ready deployment",
+		inManifest: []unstructured.Unstructured{
+			*NamespacedResource("apps/v1", "Deployment", "test", "ready"),
+		},
+		inAPI:      []runtime.Object{readyDeployment},
+		wantError:  false,
+		wantStatus: corev1.ConditionTrue,
+	}, {
+		name: "not ready deployment",
+		inManifest: []unstructured.Unstructured{
+			*NamespacedResource("apps/v1", "Deployment", "test", "notReady"),
+		},
+		inAPI:      []runtime.Object{notReadyDeployment},
+		wantError:  false,
+		wantStatus: corev1.ConditionFalse,
+	}, {
+		name: "ready and not ready deployment",
+		inManifest: []unstructured.Unstructured{
+			*NamespacedResource("apps/v1", "Deployment", "test", "ready"),
+			*NamespacedResource("apps/v1", "Deployment", "test", "notReady"),
+		},
+		inAPI:      []runtime.Object{},
+		wantError:  false,
+		wantStatus: corev1.ConditionFalse,
+	}, {
+		name: "not found deployment",
+		inManifest: []unstructured.Unstructured{
+			*NamespacedResource("apps/v1", "Deployment", "test", "notFound"),
+		},
+		inAPI:      []runtime.Object{},
+		wantError:  false,
+		wantStatus: corev1.ConditionFalse,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manifest, err := mf.ManifestFrom(mf.Slice(test.inManifest))
+			if err != nil {
+				t.Fatalf("Failed to generate manifest: %v", err)
+			}
+			kube := fake.NewSimpleClientset(test.inAPI...)
+
+			ks := &v1alpha1.KnativeServing{}
+			ks.Status.InitializeConditions()
+
+			err = CheckDeployments(kube, &manifest, &ks.Status)
+			if (err != nil) != test.wantError {
+				t.Fatalf("CheckDeployments() = %v, wantError: %v", err, test.wantError)
+			}
+
+			condition := ks.Status.GetCondition(v1alpha1.DeploymentsAvailable)
+			if condition == nil || condition.Status != test.wantStatus {
+				t.Fatalf("DeploymentAvailable = %v, want %v", condition, test.wantStatus)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -115,9 +115,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.Kna
 	stages := []func(context.Context, *mf.Manifest, *eventingv1alpha1.KnativeEventing) error{
 		r.ensureFinalizerRemoval,
 		r.install,
-		func(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
-			return common.CheckDeployments(r.kubeClientSet, manifest, &ke.Status)
-		},
+		r.checkDeployments,
 		r.deleteObsoleteResources,
 	}
 
@@ -208,6 +206,12 @@ func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, ke *eve
 	ke.Status.MarkInstallSucceeded()
 	ke.Status.Version = version.EventingVersion
 	return nil
+}
+
+func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
+	logger := logging.FromContext(ctx)
+	logger.Debug("Checking deployments")
+	return common.CheckDeployments(r.kubeClientSet, manifest, &ke.Status)
 }
 
 // Delete obsolete resources from previous versions

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -115,9 +115,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *servingv1alpha1.Knat
 	stages := []func(context.Context, *mf.Manifest, *servingv1alpha1.KnativeServing) error{
 		r.ensureFinalizerRemoval,
 		r.install,
-		func(ctx context.Context, manifest *mf.Manifest, ks *servingv1alpha1.KnativeServing) error {
-			return common.CheckDeployments(r.kubeClientSet, manifest, &ks.Status)
-		},
+		r.checkDeployments,
 		r.deleteObsoleteResources,
 	}
 
@@ -184,6 +182,13 @@ func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, instanc
 	instance.Status.MarkInstallSucceeded()
 	instance.Status.Version = version.ServingVersion
 	return nil
+}
+
+// Check for all deployments available
+func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
+	logger := logging.FromContext(ctx)
+	logger.Debug("Checking deployments")
+	return common.CheckDeployments(r.kubeClientSet, manifest, &instance.Status)
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-serving-manifest" is removed from the resource.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

As per title, this is the first function to be pulled out into common code. It makes the DeploymentCheck available from either Serving and Eventing and adds unit tests to the formerly untested code.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @jcrossley3 @aliok @houshengbo  
