### PR TITLE
Move common transformers to common code.

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/pkg/logging"
+)
+
+// Transformers returns transformers that are common to all components.
+func Transformers(ctx context.Context, obj v1alpha1.KComponent) []mf.Transformer {
+	logger := logging.FromContext(ctx)
+	return []mf.Transformer{
+		mf.InjectOwner(obj),
+		mf.InjectNamespace(obj.GetNamespace()),
+		ImageTransform(obj.GetSpec().GetRegistry(), logger),
+		ConfigMapTransform(obj.GetSpec().GetConfig(), logger),
+		ResourceRequirementsTransform(obj.GetSpec().GetResources(), logger)}
+}

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/pkg/ptr"
+)
+
+func TestCommonTransformers(t *testing.T) {
+	component := &v1alpha1.KnativeEventing{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-name",
+		},
+	}
+	transformers := Transformers(context.Background(), component)
+
+	resource := NamespacedResource("test/v1", "TestCR", "another-ns", "test-resource")
+	for _, t := range transformers {
+		t(resource)
+	}
+
+	// Only verify generic transformers are applied for simplicity.
+
+	// Verify namespace is carried over.
+	if got, want := resource.GetNamespace(), component.GetNamespace(); got != want {
+		t.Fatalf("GetNamespace() = %s, want %s", got, want)
+	}
+
+	// Verify OwnerReference is set.
+	if len(resource.GetOwnerReferences()) < 0 {
+		t.Fatalf("len(GetOwnerReferences()) = 0, expected at least 1")
+	}
+	ownerRef := resource.GetOwnerReferences()[0]
+
+	apiVersion, kind := component.GroupVersionKind().ToAPIVersionAndKind()
+	wantOwnerRef := metav1.OwnerReference{
+		APIVersion:         apiVersion,
+		Kind:               kind,
+		Name:               component.GetName(),
+		Controller:         ptr.Bool(true),
+		BlockOwnerDeletion: ptr.Bool(true),
+	}
+
+	if !cmp.Equal(ownerRef, wantOwnerRef) {
+		t.Fatalf("Unexpected ownerRef: %s", cmp.Diff(ownerRef, wantOwnerRef))
+	}
+}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -142,16 +142,11 @@ func (r *Reconciler) transform(ctx context.Context, instance *eventingv1alpha1.K
 	if err != nil {
 		return mf.Manifest{}, err
 	}
-	standard := []mf.Transformer{
-		mf.InjectOwner(instance),
-		mf.InjectNamespace(instance.GetNamespace()),
-		common.ImageTransform(&instance.Spec.Registry, logger),
-		common.ConfigMapTransform(instance.Spec.Config, logger),
-		common.ResourceRequirementsTransform(instance.Spec.Resources, logger),
-		kec.DefaultBrokerConfigMapTransform(instance, logger),
-	}
-	transforms := append(standard, platform...)
-	return r.config.Transform(transforms...)
+
+	transformers := common.Transformers(ctx, instance)
+	transformers = append(transformers, kec.DefaultBrokerConfigMapTransform(instance, logger))
+	transformers = append(transformers, platform...)
+	return r.config.Transform(transformers...)
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-eventing-manifest" is removed from the resource.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

There's quite a few common transformers used between KnativeServing and KnativeEventing. This defines them in a common place to not run at the risk of forgetting them in one or the other reconciler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @aliok @jcrossley3 @houshengbo 
