### PR TITLE
Fix requirement against openshift/api.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,11 @@ require (
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+
+	// Required indirectly by manifestival.
+	github.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
+
+	// Aligning all Kubernetes dependencies.
 	k8s.io/api => k8s.io/api v0.16.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.16.4

--- a/go.sum
+++ b/go.sum
@@ -880,7 +880,7 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

`./hack/update-deps.sh` is broken for me without this. openshift/api doesn't have published versions so that seems to trip `go mod`.

Example:

```console
$ ./hack/update-deps.sh 
warning: ignoring symlink /home/mthoemme/dev/knative/operator/test/config/serving
go: github.com/operator-framework/operator-sdk@v0.15.1 requires
	github.com/operator-framework/operator-lifecycle-manager@v0.0.0-20191115003340-16619cd27fa5 requires
	github.com/openshift/api@v3.9.1-0.20190924102528-32369d4db2ad+incompatible: invalid pseudo-version: preceding tag (v3.9.0) not found
```

/assign @houshengbo @jcrossley3 
