### PR TITLE
Use :nonroot image for the operator.

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

Current `ko` prints a fat warning that the default image will be switched soon. This adopts that new default image and suppresses the warning. See https://github.com/google/ko/issues/160.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo @jcrossley3 
